### PR TITLE
Add remarkable toolchains for 5.2.96

### DIFF
--- a/images/remarkable-toolchain/.order
+++ b/images/remarkable-toolchain/.order
@@ -1,8 +1,10 @@
 base
-5.0.58-rm1
+5.2.96-rm1
 latest-rm1
-5.0.58-rm2
+5.2.96-rm2
 latest-rm2
-5.0.58-rmpp
+5.2.96-rmpp
 latest-rmpp
+5.2.96-rmppm
+latest-rmppm
 latest

--- a/images/remarkable-toolchain/5.2.96-rm1/Dockerfile
+++ b/images/remarkable-toolchain/5.2.96-rm1/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.22.0.65/rm1/remarkable-production-image-5.2.96-rm1-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "8339cbc1d3eb3c170f89ecd75ee5eb1082c2859466790c553dc3f9ebde2c43eb  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/5.2.96-rm2/Dockerfile
+++ b/images/remarkable-toolchain/5.2.96-rm2/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.22.0.65/rm2/remarkable-production-image-5.2.96-rm2-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "d15a26ec39c20d04258ed73bb6780e7a3d5f1538062cf656f90eaf7549cb8f61  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/5.2.96-rmpp/Dockerfile
+++ b/images/remarkable-toolchain/5.2.96-rmpp/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.22.0.65/ferrari/remarkable-production-image-5.2.96-ferrari-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "5da0019b2af9709913476aa8ed424b383c2cc872823c54a2ebc91ee95ca7390d  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/5.2.96-rmppm/Dockerfile
+++ b/images/remarkable-toolchain/5.2.96-rmppm/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.22.0.65/chiappa/remarkable-production-image-5.2.96-chiappa-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "53ce902e79aae56bb3faddad59e98f189f6e966de0860f4c9e7f03419e4ed75b  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/latest-rm1/Dockerfile
+++ b/images/remarkable-toolchain/latest-rm1/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.0.58-rm1
+FROM eeems/remarkable-toolchain:5.2.96-rm1

--- a/images/remarkable-toolchain/latest-rm2/Dockerfile
+++ b/images/remarkable-toolchain/latest-rm2/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.0.58-rm2
+FROM eeems/remarkable-toolchain:5.2.96-rm2

--- a/images/remarkable-toolchain/latest-rmpp/Dockerfile
+++ b/images/remarkable-toolchain/latest-rmpp/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.0.58-rmpp
+FROM eeems/remarkable-toolchain:5.2.96-rmpp

--- a/images/remarkable-toolchain/latest-rmppm/Dockerfile
+++ b/images/remarkable-toolchain/latest-rmppm/Dockerfile
@@ -1,0 +1,2 @@
+#syntax=docker/dockerfile:1.4
+FROM eeems/remarkable-toolchain:5.2.96-rmppm

--- a/images/remarkable-toolchain/latest/Dockerfile
+++ b/images/remarkable-toolchain/latest/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:latest-rmpp
+FROM eeems/remarkable-toolchain:latest-rmppm


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded remarkable toolchain images from version 5.0.58 to 5.2.96 across all variants (rm1, rm2, rmpp).
  * Added a new toolchain variant (rmppm) with corresponding latest tag for production+ environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->