### PR TITLE
Update remakrable toolchains to 5.5.125

### DIFF
--- a/images/remarkable-toolchain/.order
+++ b/images/remarkable-toolchain/.order
@@ -1,10 +1,10 @@
 base
-5.4.107-rm1
+5.5.125-rm1
 latest-rm1
-5.4.107-rm2
+5.5.125-rm2
 latest-rm2
-5.4.107-rmpp
+5.5.125-rmpp
 latest-rmpp
-5.4.107-rmppm
+5.5.125-rmppm
 latest-rmppm
 latest

--- a/images/remarkable-toolchain/5.5.125-rm1/Dockerfile
+++ b/images/remarkable-toolchain/5.5.125-rm1/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.25.1.1/rm1/remarkable-production-image-5.5.125-rm1-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "20a19e587952da3c9a460724e361a201565c8d80d0168b07cd2f03cd54774f58  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/5.5.125-rm2/Dockerfile
+++ b/images/remarkable-toolchain/5.5.125-rm2/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.25.1.1/rm2/remarkable-production-image-5.5.125-rm2-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "b308ba093bc7c3b297e81caca840c201afb733b30c8fcf9e5a8f1ae693248095  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/5.5.125-rmpp/Dockerfile
+++ b/images/remarkable-toolchain/5.5.125-rmpp/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.25.1.1/ferrari/remarkable-production-image-5.5.125-ferrari-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "4ce06be73e8f042ff5eeb667d9ec688fda634a33b67f568a18a02284c36073fd  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/5.5.125-rmppm/Dockerfile
+++ b/images/remarkable-toolchain/5.5.125-rmppm/Dockerfile
@@ -1,0 +1,11 @@
+FROM eeems/remarkable-toolchain:base
+
+RUN <<EOT
+  curl \
+    https://storage.googleapis.com/remarkable-codex-toolchain/3.25.1.1/chiappa/remarkable-production-image-5.5.125-chiappa-public-x86_64-toolchain.sh \
+    -o install-toolchain.sh
+  echo "5e6026a7c45dd556f7e5ef50299434a8ba28703cbbc78db470610ebc08f457e5  install-toolchain.sh" | sha256sum --check
+  chmod +x install-toolchain.sh
+  ./install-toolchain.sh -y
+  rm install-toolchain.sh
+EOT

--- a/images/remarkable-toolchain/latest-rm1/Dockerfile
+++ b/images/remarkable-toolchain/latest-rm1/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.4.107-rm1
+FROM eeems/remarkable-toolchain:5.5.125-rm1

--- a/images/remarkable-toolchain/latest-rm2/Dockerfile
+++ b/images/remarkable-toolchain/latest-rm2/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.4.107-rm2
+FROM eeems/remarkable-toolchain:5.5.125-rm2

--- a/images/remarkable-toolchain/latest-rmpp/Dockerfile
+++ b/images/remarkable-toolchain/latest-rmpp/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.4.107-rmpp
+FROM eeems/remarkable-toolchain:5.5.125-rmpp

--- a/images/remarkable-toolchain/latest-rmppm/Dockerfile
+++ b/images/remarkable-toolchain/latest-rmppm/Dockerfile
@@ -1,2 +1,2 @@
 #syntax=docker/dockerfile:1.4
-FROM eeems/remarkable-toolchain:5.4.107-rmppm
+FROM eeems/remarkable-toolchain:5.5.125-rmppm


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced toolchain images version 5.5.125 for RM1, RM2, RMPP, and RMPPM variants, providing the latest production toolchain out of the box.
- Chores
  - Updated all “latest-*” tags to reference the 5.5.125 images.
  - Enhanced build robustness with checksum-verified installer execution during image creation for all variants.
  - Maintained consistent image structure and ordering across variants for easier selection and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->